### PR TITLE
[TASK] Prevent empty pageGrp tags in cat xml exports

### DIFF
--- a/Classes/View/CatXmlView.php
+++ b/Classes/View/CatXmlView.php
@@ -88,7 +88,7 @@ class CatXmlView extends AbstractExportView implements ExportViewInterface
             if (empty($page['items'])) {
                 continue;
             }
-            $output[] = "\t" . '<pageGrp id="' . $pId . '" sourceUrl="' . $page['header']['url'] . '">' . "\n";
+            $pageContent = [];
             foreach ($page['items'] as $table => $elements) {
                 foreach ($elements as $elementUid => $data) {
                     if ($this->modeOnlyNew && !empty($data['translationInfo']['translations'])) {
@@ -123,7 +123,7 @@ class CatXmlView extends AbstractExportView implements ExportViewInterface
                             );
                             continue;
                         }
-                        $output[] = sprintf(
+                        $pageContent[] = sprintf(
                             '%s<data table="%s" elementUid="%s" key="%s">%s</data>%s',
                             "\t\t",
                             $table,
@@ -134,6 +134,14 @@ class CatXmlView extends AbstractExportView implements ExportViewInterface
                         );
                     }
                 }
+            }
+            if (empty($pageContent)) {
+                continue;
+            }
+            // Write output if page is not empty
+            $output[] = "\t" . '<pageGrp id="' . $pId . '" sourceUrl="' . $page['header']['url'] . '">' . "\n";
+            foreach ($pageContent as $content) {
+                $output[] = $content;
             }
             $output[] = "\t" . '</pageGrp>' . "\r";
         }


### PR DESCRIPTION
For exports with "no hidden" and "changed / new content only" it can often happen, that there is no content inside a <pageGrp>. To prevent those empty tags, the output is built after all the contents are rendered.

See original MR: https://gitlab.com/coderscare/l10nmgr/-/merge_requests/64