### PR TITLE
Apply exclude to child elements

### DIFF
--- a/Classes/Model/L10nAccumulatedInformation.php
+++ b/Classes/Model/L10nAccumulatedInformation.php
@@ -334,8 +334,12 @@ class L10nAccumulatedInformation
                                     }
 
                                     // Hidden state for
-                                    if ($t8Tools->isParentItemHidden($table, ($this->forcedPreviewLanguage > 0 && !empty($rowPrevLang)) ? $rowPrevLang : $row,
-                                        $sysLang, $this->noHidden)) {
+                                    if ($t8Tools->isParentItemHidden(
+                                        $table,
+                                        ($this->forcedPreviewLanguage > 0 && !empty($rowPrevLang)) ? $rowPrevLang : $row,
+                                        $sysLang,
+                                        $this->noHidden
+                                    )) {
                                         continue;
                                     }
                                 }

--- a/Classes/Model/L10nAccumulatedInformation.php
+++ b/Classes/Model/L10nAccumulatedInformation.php
@@ -311,7 +311,12 @@ class L10nAccumulatedInformation
 
                                 // Check parent state of inline Elements and sys_file_references using the row or the rowPrevLang variable
                                 if ((int)$l10ncfg['applyExcludeToChildren'] === 1 && $this->noHidden) {
-                                    // Get translation overlay record to check for parent restrictions
+                                    // Check hidden state in default language
+                                    if ($t8Tools->isParentItemHidden($table, $row, $sysLang)) {
+                                        continue;
+                                    }
+
+                                    // Get translation overlay record to check for hidden parents in forced source language
                                     $prevLangInfo = $t8Tools->translationInfo(
                                         $table,
                                         $row['uid'],
@@ -325,22 +330,11 @@ class L10nAccumulatedInformation
                                             $prevLangInfo['translation_table'],
                                             $prevLangInfo['translations'][$previewLanguage]['uid']
                                         );
-                                    } elseif ($this->forcedPreviewLanguage === 0) {
-                                        // Use fallback to default language, if record does not exist in forced source language
-                                        $rowPrevLang = BackendUtility::getRecordWSOL(
-                                            $prevLangInfo['translation_table'],
-                                            $row['uid']
-                                        );
-                                    }
 
-                                    // Hidden state for
-                                    if ($t8Tools->isParentItemHidden(
-                                        $table,
-                                        ($this->forcedPreviewLanguage > 0 && !empty($rowPrevLang)) ? $rowPrevLang : $row,
-                                        $sysLang,
-                                        $this->noHidden
-                                    )) {
-                                        continue;
+                                        // Hidden state for
+                                        if (!empty($rowPrevLang) && $t8Tools->isParentItemHidden($table, $rowPrevLang, $sysLang)) {
+                                            continue;
+                                        }
                                     }
                                 }
 

--- a/Classes/Model/L10nAccumulatedInformation.php
+++ b/Classes/Model/L10nAccumulatedInformation.php
@@ -285,7 +285,6 @@ class L10nAccumulatedInformation
                                 if (isset($this->excludeIndex[$table . ':' . $row['uid']])) {
                                     continue;
                                 }
-
                                 if (!empty($row[Constants::L10NMGR_LANGUAGE_RESTRICTION_FIELDNAME])) {
                                     /** @var LanguageRestrictionCollection $languageIsRestricted */
                                     $languageIsRestricted = LanguageRestrictionCollection::load(

--- a/Classes/Model/L10nAccumulatedInformation.php
+++ b/Classes/Model/L10nAccumulatedInformation.php
@@ -286,29 +286,7 @@ class L10nAccumulatedInformation
                                     continue;
                                 }
 
-                                // Get translation overlay record to check for parent restrictions
-                                $prevLangInfo = $t8Tools->translationInfo(
-                                    $table,
-                                    $row['uid'],
-                                    $previewLanguage,
-                                    null,
-                                    '',
-                                    $previewLanguage
-                                );
-                                if (!empty($prevLangInfo) && $prevLangInfo['translations'][$previewLanguage]) {
-                                    $rowPrevLang = BackendUtility::getRecordWSOL(
-                                        $prevLangInfo['translation_table'],
-                                        $prevLangInfo['translations'][$previewLanguage]['uid']
-                                    );
-                                } elseif ($this->forcedPreviewLanguage === 0) {
-                                    // Use fallback to default language, if record does not exist in forced source language
-                                    $rowPrevLang = BackendUtility::getRecordWSOL(
-                                        $prevLangInfo['translation_table'],
-                                        $row['uid']
-                                    );
-                                }
-
-                                if (!empty($row[Constants::L10NMGR_LANGUAGE_RESTRICTION_FIELDNAME]) || !empty($rowPrevLang[Constants::L10NMGR_LANGUAGE_RESTRICTION_FIELDNAME])) {
+                                if (!empty($row[Constants::L10NMGR_LANGUAGE_RESTRICTION_FIELDNAME])) {
                                     /** @var LanguageRestrictionCollection $languageIsRestricted */
                                     $languageIsRestricted = LanguageRestrictionCollection::load(
                                         (int)$sysLang,
@@ -316,7 +294,7 @@ class L10nAccumulatedInformation
                                         $table,
                                         Constants::L10NMGR_LANGUAGE_RESTRICTION_FIELDNAME
                                     );
-                                    if ($languageIsRestricted->hasItem((int)$row['uid']) || (!empty($rowPrevLang) && $languageIsRestricted->hasItem((int)$rowPrevLang['uid']))) {
+                                    if ($languageIsRestricted->hasItem((int)$row['uid'])) {
                                         $this->excludeIndex[$table . ':' . (int)$row['uid']] = 1;
                                         continue;
                                     }
@@ -326,9 +304,40 @@ class L10nAccumulatedInformation
                                     continue;
                                 }
 
-                                // Check parent state of inline Elements and sys_file_references using the row or the rowPrevLang variable
-                                if ((int)$l10ncfg['applyExcludeToChildren'] === 1 && $t8Tools->isParentItemExcluded($table, ($this->forcedPreviewLanguage > 0 && !empty($rowPrevLang)) ? $rowPrevLang: $row, $sysLang, $this->noHidden)) {
+                                // Restrictions are only defined on default lang
+                                if ((int)$l10ncfg['applyExcludeToChildren'] === 1 && $t8Tools->isParentItemExcluded($table, $row, $sysLang)) {
                                     continue;
+                                }
+
+                                // Check parent state of inline Elements and sys_file_references using the row or the rowPrevLang variable
+                                if ((int)$l10ncfg['applyExcludeToChildren'] === 1 && $this->noHidden) {
+                                    // Get translation overlay record to check for parent restrictions
+                                    $prevLangInfo = $t8Tools->translationInfo(
+                                        $table,
+                                        $row['uid'],
+                                        $previewLanguage,
+                                        null,
+                                        '',
+                                        $previewLanguage
+                                    );
+                                    if (!empty($prevLangInfo) && $prevLangInfo['translations'][$previewLanguage]) {
+                                        $rowPrevLang = BackendUtility::getRecordWSOL(
+                                            $prevLangInfo['translation_table'],
+                                            $prevLangInfo['translations'][$previewLanguage]['uid']
+                                        );
+                                    } elseif ($this->forcedPreviewLanguage === 0) {
+                                        // Use fallback to default language, if record does not exist in forced source language
+                                        $rowPrevLang = BackendUtility::getRecordWSOL(
+                                            $prevLangInfo['translation_table'],
+                                            $row['uid']
+                                        );
+                                    }
+
+                                    // Hidden state for
+                                    if ($t8Tools->isParentItemHidden($table, ($this->forcedPreviewLanguage > 0 && !empty($rowPrevLang)) ? $rowPrevLang : $row,
+                                        $sysLang, $this->noHidden)) {
+                                        continue;
+                                    }
                                 }
 
                                 $accum[$pageId]['items'][$table][$row['uid']] = $t8Tools->translationDetails(

--- a/Classes/Model/Tools/Tools.php
+++ b/Classes/Model/Tools/Tools.php
@@ -1672,13 +1672,8 @@ class Tools
         return [null, null];
     }
 
-    public function isParentItemHidden(string $table, array $row, int $sysLang, bool $noHidden = false): bool
+    public function isParentItemHidden(string $table, array $row, int $sysLang): bool
     {
-        // Break early if the noHidden option isn't active at all
-        if (!$noHidden) {
-            return false;
-        }
-
         [$parentTable, $parentField] = $this->getParentTables($table, $row);
 
         if (!empty($parentTable) && !empty($parentField)) {
@@ -1688,12 +1683,12 @@ class Tools
 
             $parent = BackendUtility::getRecordWSOL($parentTable, (int)$row[$parentField]);
 
-            if ($noHidden && $parent['hidden']) {
+            if ($parent['hidden']) {
                 return true;
             }
 
             // Recursive call for nested inline elements and sys_file_references
-            return $this->isParentItemHidden($parentTable, $parent, $sysLang, $noHidden);
+            return $this->isParentItemHidden($parentTable, $parent, $sysLang);
         }
 
         return false;

--- a/Classes/Model/Tools/Tools.php
+++ b/Classes/Model/Tools/Tools.php
@@ -1687,6 +1687,11 @@ class Tools
                 return true;
             }
 
+            // Exclude item if parent is missing
+            if (!$parent) {
+                return true;
+            }
+
             // Recursive call for nested inline elements and sys_file_references
             return $this->isParentItemHidden($parentTable, $parent, $sysLang);
         }
@@ -1711,6 +1716,11 @@ class Tools
                 if ($languageIsRestricted->hasItem((int)$parent['uid'])) {
                     return true;
                 }
+            }
+
+            // Exclude item if parent is missing
+            if (!$parent) {
+                return true;
             }
 
             // Recursive call for nested inline elements and sys_file_references

--- a/Classes/Model/Tools/Tools.php
+++ b/Classes/Model/Tools/Tools.php
@@ -1682,6 +1682,10 @@ class Tools
         [$parentTable, $parentField] = $this->getParentTables($table, $row);
 
         if (!empty($parentTable) && !empty($parentField)) {
+            if ($parentTable === 'pages') {
+                return false;
+            }
+
             $parent = BackendUtility::getRecordWSOL($parentTable, (int)$row[$parentField]);
 
             if ($noHidden && $parent['hidden']) {

--- a/Classes/Model/Tools/Tools.php
+++ b/Classes/Model/Tools/Tools.php
@@ -1656,9 +1656,9 @@ class Tools
     private function getParentTables(string $table, array $row): array
     {
         $isInlineTable = (is_array($inlineTablesConfig = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['l10nmgr']['inlineTablesConfig']) && array_key_exists(
-                $table,
-                $inlineTablesConfig
-            ));
+            $table,
+            $inlineTablesConfig
+        ));
 
         if ($isInlineTable) {
             // Parent fields:

--- a/Classes/Model/Tools/Tools.php
+++ b/Classes/Model/Tools/Tools.php
@@ -26,6 +26,8 @@ namespace Localizationteam\L10nmgr\Model\Tools;
  * @author Kasper Skaarhoj <kasperYYYY@typo3.com>
  */
 
+use Localizationteam\L10nmgr\Constants;
+use Localizationteam\L10nmgr\LanguageRestriction\Collection\LanguageRestrictionCollection;
 use Localizationteam\L10nmgr\Traits\BackendUserTrait;
 use PDO;
 use TYPO3\CMS\Backend\Configuration\TranslationConfigurationProvider;
@@ -1649,5 +1651,47 @@ class Tools
             $errorLog = $tce->errorLog;
         }
         return [$remove, $TCEmain_cmd, $TCEmain_data, $errorLog];
+    }
+
+    public function isParentItemExcluded(string $table, array $row, int $sysLang, bool $noHidden = false): bool
+    {
+        $isInlineTable = (is_array($inlineTablesConfig = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['l10nmgr']['inlineTablesConfig']) && array_key_exists(
+            $table,
+            $inlineTablesConfig
+        ));
+
+        if ($isInlineTable) {
+            // Parent fields:
+            $parentTable = 'tt_content';
+            $parentField = $inlineTablesConfig[$table]['parentField'];
+        } elseif ($table === 'sys_file_reference') {
+            $parentTable = $row['tablenames'];
+            $parentField = 'uid_foreign';
+        }
+
+        if (!empty($parentTable) && !empty($parentField)) {
+            $parent = BackendUtility::getRecordWSOL($parentTable, (int)$row[$parentField]);
+            if (!empty($parent[Constants::L10NMGR_LANGUAGE_RESTRICTION_FIELDNAME])) {
+                /** @var LanguageRestrictionCollection $languageIsRestricted */
+                $languageIsRestricted = LanguageRestrictionCollection::load(
+                    $sysLang,
+                    true,
+                    $parentTable,
+                    Constants::L10NMGR_LANGUAGE_RESTRICTION_FIELDNAME
+                );
+                if ($languageIsRestricted->hasItem((int)$parent['uid'])) {
+                    return true;
+                }
+            }
+
+            if ($noHidden && $parent['hidden']) {
+                return true;
+            }
+
+            // Recursive call for nested inline elements and sys_file_references
+            return $this->isParentItemExcluded($parentTable, $parent, $sysLang, $noHidden);
+        }
+
+        return false;
     }
 }

--- a/Configuration/TCA/tx_l10nmgr_cfg.php
+++ b/Configuration/TCA/tx_l10nmgr_cfg.php
@@ -204,9 +204,17 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_ta
                     'default' => 0,
                 ],
             ],
+            'applyExcludeToChildren' => [
+                'exclude' => 1,
+                'label' => $l10n . ':tx_l10nmgr_cfg.applyExcludeToChildren',
+                'config' => [
+                    'type' => 'check',
+                    'default' => 0,
+                ],
+            ],
         ],
         'types' => [
-            0 => ['showitem' => 'title,filenameprefix, depth, pages, sourceLangStaticId, --palette--;;forcedSourceLanguageSettings, targetLanguages, tablelist, exclude, include, metadata, displaymode, incfcewithdefaultlanguage, pretranslatecontent, overrideexistingtranslations, sortexports'],
+            0 => ['showitem' => 'title,filenameprefix, depth, pages, sourceLangStaticId, --palette--;;forcedSourceLanguageSettings, targetLanguages, tablelist, exclude, include, metadata, displaymode, incfcewithdefaultlanguage, pretranslatecontent, overrideexistingtranslations, sortexports, applyExcludeToChildren'],
         ],
         'palettes' => [
             '1' => ['showitem' => ''],
@@ -403,9 +411,17 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('static_info_ta
                     'default' => 0,
                 ],
             ],
+            'applyExcludeToChildren' => [
+                'exclude' => 1,
+                'label' => $l10n . ':tx_l10nmgr_cfg.applyExcludeToChildren',
+                'config' => [
+                    'type' => 'check',
+                    'default' => 0,
+                ],
+            ],
         ],
         'types' => [
-            0 => ['showitem' => 'title,filenameprefix, depth, pages, --palette--;;forcedSourceLanguageSettings, targetLanguages, tablelist, exclude, include, metadata, displaymode, incfcewithdefaultlanguage, pretranslatecontent, overrideexistingtranslations, sortexports'],
+            0 => ['showitem' => 'title,filenameprefix, depth, pages, --palette--;;forcedSourceLanguageSettings, targetLanguages, tablelist, exclude, include, metadata, displaymode, incfcewithdefaultlanguage, pretranslatecontent, overrideexistingtranslations, sortexports, applyExcludeToChildren'],
         ],
         'palettes' => [
             '1' => ['showitem' => ''],

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -76,6 +76,9 @@
 			<trans-unit id="tx_l10nmgr_cfg.include" xml:space="preserve">
 				<source>Include elements (comma list of &quot;table:uid&quot; pairs):</source>
 			</trans-unit>
+			<trans-unit id="tx_l10nmgr_cfg.applyExcludeToChildren" xml:space="preserve">
+				<source>Exclude children of excluded parent elements (IRRE, sys_file_reference):</source>
+			</trans-unit>
 			<trans-unit id="tx_l10nmgr_cfg.metadata" xml:space="preserve">
 				<source>Additional Metadata (JSON formatted key value pairs):</source>
 			</trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -25,6 +25,7 @@ CREATE TABLE tx_l10nmgr_cfg
     overrideexistingtranslations tinyint(4) DEFAULT '0',
     pretranslatecontent          tinyint(4) DEFAULT '0',
     sortexports                  tinyint(4) DEFAULT '0',
+    applyExcludeToChildren       tinyint(4) DEFAULT '0',
 
     PRIMARY KEY (uid),
     KEY parent (pid)


### PR DESCRIPTION
Rows of the tables `pages` and `tt_content` can be excluded from export to specific languages (`l10nmgr_language_restriction`).  This change applies those excludes to the child records. This prevents dangling elements (sys_file_reference, IRRE, ...) in export files. It also excludes elements of hidden parents if the setting noHidden is active. If forced source language is used, the exclude settings from the source are respected.

Original MR: https://gitlab.com/coderscare/l10nmgr/-/merge_requests/65