### PR TITLE
[BUGFIX] Don't attempt to localize element that is null

### DIFF
--- a/Classes/Model/L10nBaseService.php
+++ b/Classes/Model/L10nBaseService.php
@@ -1031,7 +1031,9 @@ class L10nBaseService implements LoggerAwareInterface
                     $parent = $this->getRawRecord('tt_content', (int)$element[$parentField]);
                     $this->recursivelyCheckForRelationParents($parent, $Tlang, $parentField, $childrenField);
                 } else {
-                    $this->TCEmain_cmd['tt_content'][$element['uid']]['localize'] = $Tlang;
+                    if (isset($elemnt['uid'])) {
+                        $this->TCEmain_cmd['tt_content'][$element['uid']]['localize'] = $Tlang;
+                    }
                 }
             }
         }

--- a/Classes/Model/L10nBaseService.php
+++ b/Classes/Model/L10nBaseService.php
@@ -1031,7 +1031,7 @@ class L10nBaseService implements LoggerAwareInterface
                     $parent = $this->getRawRecord('tt_content', (int)$element[$parentField]);
                     $this->recursivelyCheckForRelationParents($parent, $Tlang, $parentField, $childrenField);
                 } else {
-                    if (isset($elemnt['uid'])) {
+                    if (isset($element['uid'])) {
                         $this->TCEmain_cmd['tt_content'][$element['uid']]['localize'] = $Tlang;
                     }
                 }


### PR DESCRIPTION
If line 1031 (recursivelyCheckForRelationParents) fails to resolve $element['uid'], don't create a localize cmd.
This avoids Type errors in processCmdmap hooks.