### PR TITLE
Respect CType specific overrides for TCA config

### DIFF
--- a/Classes/Model/Tools/Tools.php
+++ b/Classes/Model/Tools/Tools.php
@@ -987,7 +987,15 @@ class Tools
                             break;
                         }
                         $allowedFields = $this->getAllowedFieldsForTable($tInfo['translation_table'] ?? '');
-                        foreach (($GLOBALS['TCA'][$tInfo['translation_table']]['columns'] ?? []) as $field => $cfg) {
+                        $tcaCols = $GLOBALS['TCA'][$tInfo['translation_table']]['columns'] ?? [];
+                        $cType = isset($tInfo['CType']) ? $tInfo['CType'] : null;
+                        if ($cType) {
+                            $overrides = $GLOBALS['TCA']['tt_content']['types'][$cType]['columnsOverrides'] ?? null;
+                            if ($overrides) {
+                                $tcaCols = array_replace_recursive($tcaCols, $overrides);
+                            }
+                        }
+                        foreach ($tcaCols as $field => $cfg) {
                             if (!in_array($field, $allowedFields)) {
                                 continue;
                             }


### PR DESCRIPTION
I have a few general purpose columns, that are shared between CTypes. The implementation differs between them, and is setup via overrides for the specific CType.

l10nmgr doesn't seem to respect column overrides for CTypes, resulting in these general purpose columns not being detected for export (if they don't have a default configuration).

This pull request adds the handling of CType specific overrides.