### PR TITLE
[BUGFIX] Avoid TypeError

### DIFF
--- a/Classes/Controller/ConfigurationManager.php
+++ b/Classes/Controller/ConfigurationManager.php
@@ -51,9 +51,9 @@ use TYPO3\CMS\Fluid\View\StandaloneView;
 class ConfigurationManager extends BaseModule
 {
     /**
-     * @var array
+     * @var array|bool
      */
-    public array $pageinfo = [];
+    public $pageinfo = [];
 
     /**
      * @var array Cache of the page details already fetched from the database


### PR DESCRIPTION
`Cannot assign bool to property Localizationteam\L10nmgr\Controller\ConfigurationManager::$pageinfo of type array` is thrown, if BU::readPageAccess returns false, i.e. if no page was selected in page tree.