### PR TITLE
[BUGFIX] Make export parameters persist accross requests

### DIFF
--- a/Classes/Controller/LocalizationModuleController.php
+++ b/Classes/Controller/LocalizationModuleController.php
@@ -126,6 +126,7 @@ class LocalizationModuleController extends BaseModule12
         // @extensionScannerIgnoreLine
         $this->id = (int)($request->getQueryParams()['id'] ?? $request->getParsedBody()['id'] ?? 0);
         $this->srcPID = (int)($request->getQueryParams()['srcPID'] ?? $request->getParsedBody()['srcPID'] ?? 0);
+        $this->previewLanguage = (int)($request->getQueryParams()['export_xml_forcepreviewlanguage'] ?? $request->getParsedBody()['export_xml_forcepreviewlanguage'] ?? 0);
         $this->menuConfig();
     }
 
@@ -469,6 +470,7 @@ class LocalizationModuleController extends BaseModule12
         $importExcel = GeneralUtility::_POST('import_excel');
         $exportExcel = GeneralUtility::_POST('export_excel');
         $checkExports = GeneralUtility::_POST('check_exports') ?? false;
+        $export_xml_forcepreviewlanguage_only = GeneralUtility::_POST('export_xml_forcepreviewlanguage_only');
 
         if ($importAsDefaultLanguage) {
             $this->l10nBaseService->setImportAsDefaultLanguage(true);
@@ -510,7 +512,7 @@ class LocalizationModuleController extends BaseModule12
             if ($export_xml_forcepreviewlanguage > 0) {
                 $viewClass->setForcedSourceLanguage($export_xml_forcepreviewlanguage);
             }
-            if (GeneralUtility::_POST('export_xml_forcepreviewlanguage_only')) {
+            if ($export_xml_forcepreviewlanguage_only) {
                 $viewClass->setOnlyForcedSourceLanguage();
             }
             if ($this->MOD_SETTINGS['onlyChangedContent'] ?? false) {
@@ -581,6 +583,9 @@ class LocalizationModuleController extends BaseModule12
             'existingExportsOverview' => $existingExportsOverview,
             'isImport' => $isImport,
             'importSuccess' => $importSuccess,
+            'check_exports' => $checkExports,
+            'import_asdefaultlanguage' => $importAsDefaultLanguage,
+            'export_xml_forcepreviewlanguage_only' => $export_xml_forcepreviewlanguage_only,
             'previewLanguageMenu' => $this->makePreviewLanguageMenu(),
             'flashMessageHtml' => $flashMessageHtml,
             'internalFlashMessage' => $internalFlashMessage,

--- a/Classes/View/AbstractExportView.php
+++ b/Classes/View/AbstractExportView.php
@@ -199,22 +199,23 @@ abstract class AbstractExportView implements ExportViewInterface
             $fileType = 'catxml';
         }
 
-        $sourceLanguageId = $this->l10ncfgObj->getForcedSourceLanguage() ?: 0;
-        $sourceLanguageConfiguration = $this->site->getAvailableLanguages($this->getBackendUser())[$sourceLanguageId] ?? null;
+        $sourceLanguageId = $this->forcedSourceLanguage ?: 0;
+        try {
+            $sourceLanguageConfiguration = $this->site->getLanguageById($sourceLanguageId);
+        } catch(\InvalidArgumentException $e) {
+            $sourceLanguageConfiguration = null;
+        }
         if ($sourceLanguageConfiguration instanceof SiteLanguage) {
-            if ($this->typo3Version->getMajorVersion() < 12) {
-                $sourceLang = $sourceLanguageConfiguration->getLocale() ?: $sourceLanguageConfiguration->getTwoLetterIsoCode();
-            } else {
-                $sourceLang = $sourceLanguageConfiguration->getLocale()->getName() ?: $sourceLanguageConfiguration->getLocale()->getLanguageCode();
-            }
+            $sourceLang = $sourceLanguageConfiguration->getHreflang();
+        }
+        try {
+            $targetLanguageConfiguration = $this->site->getLanguageById($this->targetLanguage);
+        } catch(\InvalidArgumentException $e) {
+            $targetLanguageConfiguration = null;
         }
         $targetLanguageConfiguration = $this->site->getAvailableLanguages($this->getBackendUser())[$this->targetLanguage] ?? null;
         if ($targetLanguageConfiguration instanceof SiteLanguage) {
-            if ($this->typo3Version->getMajorVersion() < 12) {
-                $targetLang = $targetLanguageConfiguration->getLocale() ?: $targetLanguageConfiguration->getTwoLetterIsoCode();
-            } else {
-                $targetLang = $targetLanguageConfiguration->getLocale()->getName() ?: $targetLanguageConfiguration->getLocale()->getLanguageCode();
-            }
+            $targetLang = $targetLanguageConfiguration->getHreflang();
         }
         if ($sourceLang !== '' && $targetLang !== '') {
             $fileNamePrefix = (trim($this->l10ncfgObj->getFileNamePrefix())) ? $this->l10ncfgObj->getFileNamePrefix() . '_' . $fileType : $fileType;

--- a/Resources/Private/Partials/LocalizationModule/Modules/ExportExcel.html
+++ b/Resources/Private/Partials/LocalizationModule/Modules/ExportExcel.html
@@ -9,7 +9,7 @@
                 <div class="form-group mb-2">
                     <div class="checkbox">
                         <label>
-                            <input type="checkbox" value="1" name="check_exports" />
+                            <input type="checkbox" value="1" name="check_exports" {f:if(condition:'{moduleContent.check_exports}',then:'checked="checked"')}/>
                             <f:translate key="{lll}export.xml.check_exports.title" />
                         </label>
                     </div>
@@ -17,7 +17,7 @@
                 <div class="form-group mb-2">
                     <div class="checkbox">
                         <label>
-                            <input type="checkbox" value="1" name="import_asdefaultlanguage" />
+                            <input type="checkbox" value="1" name="import_asdefaultlanguage" {f:if(condition:'{moduleContent.import_asdefaultlanguage}',then:'checked="checked"')}/>
                             <f:translate key="{lll}import.xml.asdefaultlanguage.title"/>
                         </label>
                     </div>
@@ -42,7 +42,7 @@
                                     <input type="checkbox" value="1" name="export_xml_forcepreviewlanguage_only" checked="checked" disabled="disabled" />
                                 </f:then>
                                 <f:else>
-                                    <input type="checkbox" value="1" name="export_xml_forcepreviewlanguage_only" />
+                                    <input type="checkbox" value="1" name="export_xml_forcepreviewlanguage_only" {f:if(condition:'{moduleContent.export_xml_forcepreviewlanguage_only}',then:'checked="checked"')} />
                                 </f:else>
                             </f:if>
                             <f:translate key="{lll}export.xml.source-language-only.title"/>


### PR DESCRIPTION
This commit makes the parameters persist when exporting or refreshing the LocalizationModule.
It also changes the way, the export filename is generated, because a Locale can be the same for multiple different site languages, that use the same locale. It is using the hreflang instead, which might be a better indicator.
