### PR TITLE
[BUGFIX] Avoid PHP warning

### DIFF
--- a/Classes/Model/L10nBaseService.php
+++ b/Classes/Model/L10nBaseService.php
@@ -381,7 +381,12 @@ class L10nBaseService implements LoggerAwareInterface
                                     && is_array($inputArray[$table][$elementUid])
                                     && array_key_exists($key, $inputArray[$table][$elementUid])
                                 ) {
-                                    [$Ttable, $TuidString, $Tfield, $Tpath] = explode(':', $key);
+                                    $parts = explode(':', $key);
+                                    $Ttable = $parts[0];
+                                    $TuidString = $parts[1];
+                                    $Tfield = $parts[2];
+                                    $Tpath = $parts[3] ?? null;
+                                    
                                     [$Tuid, $Tlang, $TdefRecord] = explode('/', $TuidString);
                                     if (!$this->createTranslationAlsoIfEmpty
                                         && $inputArray[$table][$elementUid][$key] == ''


### PR DESCRIPTION
Avoid notices because of old code
```
Core: Error handler (BE): PHP Warning: Undefined array key 3 in /.../vendor/localizationteam/l10nmgr/Classes/Model/L10nBaseService.php line 384
```