### PR TITLE
Remove deprecated PageTSConfig import from ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -38,10 +38,6 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][L10nmgrFileGarba
     'additionalFields' => L10nmgrAdditionalFieldProvider::class,
 ];
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-    '@import \'EXT:l10nmgr/Configuration/TSConfig/PageTSConfig.typoscript\''
-);
-
 $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',l10nmgr_configuration,l10nmgr_configuration_next_level';
 
 LanguageRestrictionRegistry::getInstance()->registerField(


### PR DESCRIPTION
'@import \'EXT:l10nmgr/Configuration/TSConfig/PageTSConfig.typoscript\'' points to a missing file, causing log spam with "[WARNING] request="54a34497e763d" component="TYPO3.CMS.Core.TypoScript.Parser.TypoScriptParser": The "/vendor/localizationteam/l10nmgr/Configuration/TSConfig" directory does not exist."